### PR TITLE
removed asynchonous code in setup method

### DIFF
--- a/Pod/Classes/PickerView.swift
+++ b/Pod/Classes/PickerView.swift
@@ -226,21 +226,17 @@ public class PickerView: UIView {
         setupSelectionImageView()
         setupDefaultSelectionIndicator()
         
-        // Setup UITableView data source & delegate in background
-        // Reason: When PickerView scrollingStyle is set to .Infinite and the data source is huge, setting UITableView data source & delegate
-        // on main queue can causes a little delay in the transition animation (push or modal animation)
-        let priority = DISPATCH_QUEUE_PRIORITY_BACKGROUND
-        //dispatch_async(dispatch_get_global_queue(priority, 0)) {
-            self.tableView.delegate = self
-            self.tableView.dataSource = self
-            self.tableView.reloadData()
-            
-            //dispatch_async(dispatch_get_main_queue(),{
-                // Some UI Adjustments we need to do after setting UITableView data source & delegate.
-                self.configureFirstSelection()
-                self.adjustSelectionOverlayHeightConstraint()
-            //})
-        //}
+        self.tableView.delegate = self
+        self.tableView.dataSource = self
+        self.tableView.reloadData()
+        
+        // This needs to be done after a delay - I am guessing it basically needs to be called once 
+        // the view is already displaying
+        dispatch_async(dispatch_get_main_queue(),{
+            // Some UI Adjustments we need to do after setting UITableView data source & delegate.
+            self.configureFirstSelection()
+            self.adjustSelectionOverlayHeightConstraint()
+        })
     }
     
     private func setupTableView() {

--- a/Pod/Classes/PickerView.swift
+++ b/Pod/Classes/PickerView.swift
@@ -230,17 +230,17 @@ public class PickerView: UIView {
         // Reason: When PickerView scrollingStyle is set to .Infinite and the data source is huge, setting UITableView data source & delegate
         // on main queue can causes a little delay in the transition animation (push or modal animation)
         let priority = DISPATCH_QUEUE_PRIORITY_BACKGROUND
-        dispatch_async(dispatch_get_global_queue(priority, 0)) {
+        //dispatch_async(dispatch_get_global_queue(priority, 0)) {
             self.tableView.delegate = self
             self.tableView.dataSource = self
             self.tableView.reloadData()
             
-            dispatch_async(dispatch_get_main_queue(),{
+            //dispatch_async(dispatch_get_main_queue(),{
                 // Some UI Adjustments we need to do after setting UITableView data source & delegate.
                 self.configureFirstSelection()
                 self.adjustSelectionOverlayHeightConstraint()
-            })
-        }
+            //})
+        //}
     }
     
     private func setupTableView() {


### PR DESCRIPTION
I had a crash with bad access in the setup method, where it's running in the background thread.

Unfortunately I didn't save the exception. 

 It was on the simulator and only happened once out of maybe 30 starts but I really don't want this to happen in my app on a customer's device. Especially because it was so rare. Those bugs are hard / impossible to debug. 

IMO it's a mistake to do anything asynchronously that has to do with views. Views must be modified in the main thread. They are single threaded. I recall this being mentioned in Apple's documentation somewhere too. 

Submitting this as change request - integrate it if you agree, or not if you don't ;)

I am grateful you wrote this code, so this is giving back.
